### PR TITLE
Use monospace fonts in both <pre> and <code> tags

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -979,8 +979,8 @@ a.picture-frame-fifth .play {
 
 
 /* code styling */
-code {
-  font-family: "Courier New";
+pre, code {
+  font-family: "Inconsolata", "Courier New";
   font-size: 12px;
 }
 code strong {


### PR DESCRIPTION
The output from Redcarpet + Pygments was missing `<code>` tags, resulting in a proportional font being used in code samples. 

It also now tries to use Inconsolata first (since this is what was already being used in the Terminal-style code samples).

Closes #25.
