### PR TITLE
Update event filter for asterisk RTPAUDIOQOS events

### DIFF
--- a/views/docs/getting-started/asterisk.md
+++ b/views/docs/getting-started/asterisk.md
@@ -39,7 +39,7 @@ secret = mypassword
 read = all
 write = all
 eventfilter = !Event: RTCP*
-eventfilter = !*Variable: RTPAUDIOQOS*
+eventfilter = !Variable: RTPAUDIOQOS*
 ```
 
 Note that the user needs acess to all AMI events and actions. Also, we have setup an event filter here to prevent sending Adhearsion RTCP and QOS events. This is optional, but recommended, because while Asterisk generates a great number of these events Adhearsion cannot normally do anything useful with them. Thus, we can improve Adhearsion's performance by not sending it these events in the first place.


### PR DESCRIPTION
The suggested event filters on the [Asterisk getting started page](http://adhearsion.com/docs/getting-started/asterisk) didn't work for me on Asterisk 1.8.13.0;  RTPAUDIOQOS\* SetVar events continued to come through to Adhearsion.

This patch updates the pattern to something that works on Asterisk 1.8, and I expect on others.
