### PR TITLE
http://adhearsion.com/irc doesn't work

### DIFF
--- a/views/irc.haml
+++ b/views/irc.haml
@@ -1,0 +1,17 @@
+- title "IRC", false
+
+.inner
+  .full-width
+    .three-fourth.last
+      %h1 Adhearsion IRC Chatroom
+      .pane
+        %h2 Connect info:
+        %h3
+          Room:
+          %a{href: "irc://irc.freenode.net/adhearsion"}#adhearsion
+        %h3 Network: irc.freenode.net
+        %h2 History
+        %p
+          You can also view a full history of every conversation at
+          %a{href: "http://irclogger.com/.adhearsion/"} IRC logger.
+    .clear


### PR DESCRIPTION
[The route](https://github.com/adhearsion/adhearsion-website/blob/master/app.rb#L84-L88) is set up to load the haml template, but it looks like we don't have an `irc.haml`  
