### PR TITLE
Fix typo in logging doc for outputters

### DIFF
--- a/views/docs/logging.md
+++ b/views/docs/logging.md
@@ -24,7 +24,7 @@ You may change the location of the log file by altering the `config.platform.log
 
 <pre class="terminal">
 
-ADHEARSION_PLATFORM_LOGGING_OUTPUTTERS=/var/log/adhearsion.log ahn start -
+AHN_PLATFORM_LOGGING_OUTPUTTERS=/var/log/adhearsion.log ahn start -
 </pre>
 
 ### Log to syslog


### PR DESCRIPTION
Fixed typo in logging doc to read: `AHN_PLATFORM_LOGGING_OUTPUTTERS`